### PR TITLE
feat(speakable): adds json+ld speakable content

### DIFF
--- a/src/html.js
+++ b/src/html.js
@@ -1,0 +1,49 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+export default function HTML(props) {
+  return (
+    <html {...props.htmlAttributes}>
+      <head>
+        <meta charSet="utf-8" />
+        <meta httpEquiv="x-ua-compatible" content="ie=edge" />
+        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+        {props.headComponents}
+      </head>
+      <body {...props.bodyAttributes}>
+        {props.preBodyComponents}
+        <noscript key="noscript" id="gatsby-noscript">
+          This app works best with JavaScript enabled.
+        </noscript>
+        <div key={`body`} id="___gatsby" dangerouslySetInnerHTML={{ __html: props.body }} />
+        {props.postBodyComponents}
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: `
+          {
+            "@context": "http://schema.org/",
+            "@type": "WebPage",
+            "name": "Spokestack",
+            "speakable": {
+              "@type": "SpeakableSpecification",
+              "cssSelector": [".spokestack-speakable"]
+            },
+            "url": "https://spokestack.io"
+          }
+        `
+          }}
+        />
+      </body>
+    </html>
+  )
+}
+
+HTML.propTypes = {
+  htmlAttributes: PropTypes.object,
+  headComponents: PropTypes.array,
+  bodyAttributes: PropTypes.object,
+  preBodyComponents: PropTypes.array,
+  body: PropTypes.string,
+  postBodyComponents: PropTypes.array
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -52,7 +52,7 @@ export default function Index({ data, location }: Props) {
       <SEO title={siteTitle} keywords={['spokestack', 'mobile', 'voice']} />
       <header css={styles.header}>
         <h1 css={styles.headerText}>Give your mobile app a voice&trade;</h1>
-        <h4 css={[styles.headerText, styles.h4]}>
+        <h4 css={[styles.headerText, styles.h4]} className="spokestack-speakable">
           Spokestack is a powerful platform of open source libraries and robust services to make
           your app fully voice-enabled.
         </h4>


### PR DESCRIPTION
It's kinda meh that I needed to `cp .cache/default-html.js src/html.js` in order to add a sole script to the body.

I'm just providing this PR as an example of how to achieve adding speakable content. There hasn't been official word yet on what content should to be speakable.

[Line 20](https://github.com/spokestack/spokestack-website/compare/develop...rtm/speakable?expand=1#diff-58826c9c508b82875d8f9a9872d19e2dR20) is the beginning of the script which includes the JSON+LD content. The format follows what I wrote about [here](https://github.com/spokestack/spokestack-website/compare/develop...rtm/speakable?expand=1#diff-58826c9c508b82875d8f9a9872d19e2dR20) in order for the Spokestack Extension to find speakable content.

As you can see, a single `.class` (in this case) is used to determine what is speakable. In this case the class is global and therefore not hashed. It would be interesting to produce a solution in which the `cssSelector` values in the JSON+LD get hashed and scoped as well.

I did test the Spokestack Extension against a production build; it's good. Testing against the development env has some asynchronous issues atm.