### PR TITLE
fix(text): fix typo in sample markdown text

### DIFF
--- a/src/components/SampleVoices.tsx
+++ b/src/components/SampleVoices.tsx
@@ -18,7 +18,7 @@ import voices from '../utils/voices'
 const defaultStrings = {
   ipa: 'Hello, welcome to {{spoʊkstæk}}. What would you like to say?',
   md:
-    'Hello, welcome to (spokestack)[ipa:"spoʊkstæk"]. Would would you like to say?'
+    'Hello, welcome to (spokestack)[ipa:"spoʊkstæk"]. What would you like to say?'
 }
 
 const options = voices.map((voice) => ({


### PR DESCRIPTION
Noticed a small typo in the SMD text, so figured I'd just fix instead of alerting you about it.

**Edit**: ha; note the typo I created in my commit message to replace the one on the site. Gonna have to erase that from history...