### PR TITLE
ci: invalidate cloudfront on deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,6 +58,9 @@ jobs:
       - run:
           name: Build and push static site
           command: aws s3 sync --delete public s3://beta.spokestack.io/
+      - run:
+          name: Invalidate the cdn caches
+          command: aws cloudfront create-invalidation --distribution-id E1VWEXJMB3URMJ --paths "/*"
 
   deploy_production:
     docker:
@@ -77,6 +80,9 @@ jobs:
       - run:
           name: Build and push static site
           command: aws s3 sync --delete public s3://spokestack.io/
+      - run:
+          name: Invalidate the cdn caches
+          command: aws cloudfront create-invalidation --distribution-id E1P3DI1Q9L6OBH --paths "/*"
 
 workflows:
   version: 2


### PR DESCRIPTION
These changes request an invalidation on the cdns after deploy to s3.