### PR TITLE
ci: enable cloudfront awscli commands

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,6 +59,9 @@ jobs:
           name: Build and push static site
           command: aws s3 sync --delete public s3://beta.spokestack.io/
       - run:
+          name: Enable cloudfront cli
+          command: avp aws configure set preview.cloudfront true
+      - run:
           name: Invalidate the cdn caches
           command: aws cloudfront create-invalidation --distribution-id E1VWEXJMB3URMJ --paths "/*"
 
@@ -80,6 +83,9 @@ jobs:
       - run:
           name: Build and push static site
           command: aws s3 sync --delete public s3://spokestack.io/
+      - run:
+          name: Enable cloudfront cli
+          command: avp aws configure set preview.cloudfront true
       - run:
           name: Invalidate the cdn caches
           command: aws cloudfront create-invalidation --distribution-id E1P3DI1Q9L6OBH --paths "/*"


### PR DESCRIPTION
These changes enable the preview mode for cloudfront commands before running the cloudfront invalidation.