### PR TITLE
docs: update TTS documentation; fix typo

### DIFF
--- a/content/docs/Concepts/tts.md
+++ b/content/docs/Concepts/tts.md
@@ -7,16 +7,25 @@ draft: false
 
 Spokestack offers a rich, controllable text-to-speech (TTS) system. The voices available to use in your app are determined by your API client identifier, but we offer a demo voice to all users so that you can try custom TTS in your app without making a commitment. If you need a unique voice for your brand, [contact us](mailto:hello@spokestack.io), and we can work with you to create a custom experience for your users.
 
-Apart from voice selection, Spokestack's TTS enables fine control over pronunciation by supporting a subset of the [SSML](https://www.w3.org/TR/speech-synthesis11/) standard. Synthesis defaults to using raw text, but you can opt into using SSML instead; see the platform-specific documentation ([iOS](https://spokestack.github.io/spokestack-ios/Classes/TextToSpeechInput.html) | [Android](https://www.javadoc.io/doc/io.spokestack/spokestack-android/latest/io/spokestack/spokestack/tts/SpokestackTTSClient.html)) for details.
+Apart from voice selection, Spokestack's TTS enables fine control over pronunciation by supporting a subset of both the [SSML](https://www.w3.org/TR/speech-synthesis11/) standard and [Speech Markdown](https://www.speechmarkdown.org/) syntax. Synthesis defaults to using raw text, but you can opt into using one of these other markups instead; see the platform-specific documentation ([iOS](https://spokestack.github.io/spokestack-ios/Classes/TextToSpeechInput.html) | [Android](https://www.javadoc.io/doc/io.spokestack/spokestack-android/latest/io/spokestack/spokestack/tts/SpokestackTTSClient.html)) for details.
 
-### SSML in Spokestack
+## SSML
 
 SSML is an XML-based markup language; the root element must be `<speak>`. Aside from `speak`, Spokestack supports the following elements:
 
 - [s](https://www.w3.org/TR/speech-synthesis11/#edef_sentence)
 - [break](https://www.w3.org/TR/speech-synthesis11/#edef_break)
-- [say-as](https://www.w3.org/TR/speech-synthesis11/#S3.1.9) with an `interpret-as` attribute of "characters", "spell-out", or "digits"
+- [prosody](https://www.w3.org/TR/speech-synthesis11/#S3.2.4), `pitch` and `rate` attributes only
 - [phoneme](https://www.w3.org/TR/speech-synthesis11/#S3.1.10) with the `alphabet` attribute set to "ipa"
+- [say-as](https://www.w3.org/TR/speech-synthesis11/#S3.1.9), `interpret-as` attribute only, with one of the following values:
+  - `cardinal`
+  - `characters`
+  - `digits`
+  - `number`
+  - `ordinal`
+  - `spell-out`
+  - `telephone`
+  - `unit`
 
 Note that long inputs should be split into separate `s` ("sentence") elements for the best performance.
 
@@ -33,11 +42,11 @@ Currently, Spokestack is focused on pronunciation of English words and loan word
 
 Using invalid characters will not cause an error, but it might result in unexpected pronunciation.
 
-### Some brief examples
+### Examples
 
 - When you just can't give up that web prefix:
 
-  `<speak>See all our products at <say-as interpret-as="characters">www</say-as> dot my company dot com</speak>`
+  `<speak>See all our products at <say-as interpret-as="characters">www</say-as> dot my company dot com.</speak>`
 
 - Insert a pregnant pause:
 
@@ -46,3 +55,28 @@ Using invalid characters will not cause an error, but it might result in unexpec
 - Customize pronunciation to make a point:
 
   `<speak>I don't care what you say; it's pronounced <phoneme alphabet="ipa" ph="gɪf">gif</phoneme>, not <phoneme alphabet="ipa" ph="dʒɪf">gif</phoneme>!</speak>`
+
+## Speech Markdown
+
+Speech Markdown is a convenience wrapper around SSML syntax, so Spokestack's support for it mirrors our SSML support. The structure of Speech Markdown is flatter than SSML's; support for the SSML elements above translates into the following Speech Markdown syntax:
+
+- [break](https://www.speechmarkdown.org/syntax/break/)
+- [pitch](https://www.speechmarkdown.org/syntax/pitch/)
+- [rate](https://www.speechmarkdown.org/syntax/rate/)
+- [ipa](https://www.speechmarkdown.org/syntax/ipa/)
+- [cardinal](https://www.speechmarkdown.org/syntax/cardinal/)
+- [characters](https://www.speechmarkdown.org/syntax/characters/)
+- [number](https://www.speechmarkdown.org/syntax/number/)
+- [ordinal](https://www.speechmarkdown.org/syntax/ordinal/)
+- [phone/telephone](https://www.speechmarkdown.org/syntax/phone/)
+- [unit](https://www.speechmarkdown.org/syntax/unit/)
+
+### Examples
+
+Here are the above SSML examples translated into Speech Markdown:
+
+```text
+See all our products at (www)[characters] dot my company dot com.
+Today's stock price [500ms] fell three percent.
+I don't care what you say; it's pronounced (gif)[/gɪf/], not (gif)[/dʒɪf/]!
+```

--- a/content/docs/Concepts/wakeword-models.md
+++ b/content/docs/Concepts/wakeword-models.md
@@ -7,7 +7,7 @@ draft: false
 
 Spokestack provides pretrained [TensorFlow Lite](https://www.tensorflow.org/lite) models that enable on-device wakeword detection. These free models, however, only recognize the word "Spokestack"; in order to have your app respond to a different word or phrase, you'll need new models. If machine learning is outside your wheelhouse and you'd like a customized wakeword for your app, stop reading here and [drop us a line](mailto:hello@spokestack.io). We're happy to help.
 
-If building a custom model sounds like fun, though, soldier on. We'll describe the design of the models and their input/output shapes below; see [the configuration guide](pipeline-configuration) for more information about hyperparameters. Spokestack uses three separate models; they operate continuously, each feeding output into the next, for both effeciency and accuracy. We'll go over them in the order in which they're used. See the list of references at the end for descriptions of any unfamiliar terminology, and let us know if we missed anything!
+If building a custom model sounds like fun, though, soldier on. We'll describe the design of the models and their input/output shapes below; see [the configuration guide](pipeline-configuration) for more information about hyperparameters. Spokestack uses three separate models; they operate continuously, each feeding output into the next, for both efficiency and accuracy. We'll go over them in the order in which they're used. See the list of references at the end for descriptions of any unfamiliar terminology, and let us know if we missed anything!
 
 ## Filter
 


### PR DESCRIPTION
### PR Checklist

Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [x] I am requesting to **pull a topic/feature/bugfix branch** (right side). In other words, not _master_.
- [x] I have run `npm test` against my changes and tests pass.
- [x] I have added or edited necessary documentation, or no docs changes are needed.

### Description

I realized the other day that we don't mention Speech Markdown in our main TTS documentation, and it hadn't been updated with SSML features we added a couple months ago, so I went ahead and fixed that.

Also found an unfortunate typo in the wakeword doc.