### PR TITLE
feat(nlu): show individual CDN URLs for NLU model files

### DIFF
--- a/src/components/EditButtons.tsx
+++ b/src/components/EditButtons.tsx
@@ -1,9 +1,9 @@
 import * as theme from '../styles/theme'
 
-import React, { useState } from 'react'
+import React, { useRef, useState } from 'react'
+import { SerializedStyles, css } from '@emotion/core'
 
 import SVGIcon from './SVGIcon'
-import { css } from '@emotion/core'
 
 interface CopyProps {
   inputRef: React.MutableRefObject<HTMLInputElement | HTMLTextAreaElement>
@@ -26,6 +26,41 @@ export function CopyButton({ inputRef, title }: CopyProps) {
     <a title={title} onClick={copy} css={styles.editButton}>
       <SVGIcon icon={copied ? '#checkmark' : '#copy'} extraCss={styles.icon} />
     </a>
+  )
+}
+
+interface CopyInputProps {
+  extraCss?: SerializedStyles | SerializedStyles[]
+  id: string
+  title: string
+  value: string
+}
+
+export function CopyInputWithButton({
+  extraCss,
+  id,
+  title,
+  value
+}: CopyInputProps) {
+  const inputRef = useRef<HTMLInputElement>(null)
+  return (
+    <div css={[styles.copyInput].concat(extraCss)}>
+      <div css={styles.row}>
+        <label className="label" htmlFor={id}>
+          {title}
+        </label>
+        <CopyButton title={`Copy ${title}`} inputRef={inputRef} />
+      </div>
+      <input
+        ref={inputRef}
+        readOnly
+        id={id}
+        type="text"
+        className="input"
+        onFocus={() => inputRef.current.select()}
+        value={value}
+      />
+    </div>
   )
 }
 
@@ -72,5 +107,15 @@ const styles = {
     fill: ${theme.primary};
     width: 20px;
     height: 20px;
+  `,
+  copyInput: css`
+    display: flex;
+    flex-direction: column;
+  `,
+  row: css`
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
   `
 }

--- a/src/components/SampleVoices.tsx
+++ b/src/components/SampleVoices.tsx
@@ -60,7 +60,7 @@ export default class SampleVoices extends PureComponent<Props, State> {
   }
 
   getVoices() {
-    return client
+    const query = client
       .query<{ listVoices: { description: string; name: string }[] }>({
         query: LIST_VOICES,
         fetchPolicy: 'network-only'
@@ -85,6 +85,7 @@ export default class SampleVoices extends PureComponent<Props, State> {
           )
         })
       })
+    return query
   }
 
   getAudio = async () => {

--- a/src/components/Wakeword.tsx
+++ b/src/components/Wakeword.tsx
@@ -5,7 +5,7 @@ import { getWakeword, uploadWakeword } from '../utils/wakeword'
 
 import Button from './Button'
 import Card from './Card'
-import { CopyButton } from './EditButtons'
+import { CopyInputWithButton } from './EditButtons'
 import { MIN_DEFAULT_MEDIA_QUERY } from 'typography-breakpoint-constants'
 import SVGIcon from './SVGIcon'
 import WakewordCheckmark from './WakewordCheckmark'
@@ -35,7 +35,6 @@ interface State {
 }
 
 export default class Wakeword extends PureComponent<Props, State> {
-  private tokenRef = React.createRef<HTMLInputElement>()
   wakeword: string
 
   static defaultProps = {
@@ -165,19 +164,9 @@ export default class Wakeword extends PureComponent<Props, State> {
             {recorded >= numRecordings && token ? (
               <div css={styles.token}>
                 <p>The following token is proof of your recordings.</p>
-                <div css={styles.row}>
-                  <label className="label" htmlFor="wakeword-token">
-                    Response token
-                  </label>
-                  <CopyButton title="Copy Token" inputRef={this.tokenRef} />
-                </div>
-                <input
-                  ref={this.tokenRef}
-                  readOnly
+                <CopyInputWithButton
                   id="wakeword-token"
-                  type="text"
-                  className="input"
-                  onFocus={() => this.tokenRef.current.select()}
+                  title="Response token"
                   value={token}
                 />
               </div>
@@ -234,12 +223,6 @@ const styles = {
     width: 100%;
     display: flex;
     flex-direction: column;
-  `,
-  row: css`
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
-    align-items: center;
   `,
   goAgainButton: css`
     margin-top: 20px;

--- a/src/components/account/NluModel.tsx
+++ b/src/components/account/NluModel.tsx
@@ -8,6 +8,7 @@ import {
 
 import AccountCard from './AccountCard'
 import Color from 'color'
+import { CopyInputWithButton } from '../EditButtons'
 import React from 'react'
 import SVGIcon from '../SVGIcon'
 import { adjustFontSizeTo } from '../../styles/typography'
@@ -19,9 +20,12 @@ interface Props {
   model: NluModelType
 }
 
+const rurlFilename = /\/[^/]+?$/
+
 export default function NluModel({ model }: Props) {
   const isShared = model.source === NluModelSource.SHARED
   const isPending = model.state === NluModelState.PENDING
+  const modelUrl = model.modelUrl.replace(rurlFilename, '')
   return (
     <AccountCard
       title={titleCase(model.name)}
@@ -36,6 +40,24 @@ export default function NluModel({ model }: Props) {
           ? 'shared. It is available to all Spokestack accounts.'
           : 'only available to your account.'}
       </p>
+      <CopyInputWithButton
+        id={`vocab-${model.id}`}
+        extraCss={styles.copyInput}
+        title="vocab.txt CDN URL"
+        value={`${modelUrl}/vocab.txt`}
+      />
+      <CopyInputWithButton
+        id={`nlu-${model.id}`}
+        extraCss={styles.copyInput}
+        title="nlu.tflite CDN URL"
+        value={`${modelUrl}/nlu.tflite`}
+      />
+      <CopyInputWithButton
+        id={`metadata-${model.id}`}
+        extraCss={styles.copyInput}
+        title="metadata.json CDN URL"
+        value={`${modelUrl}/metadata.json`}
+      />
       <div css={styles.buttons}>
         <a
           className="btn btn-transparent"
@@ -46,7 +68,7 @@ export default function NluModel({ model }: Props) {
             className="icon"
             extraCss={styles.downloadIcon}
           />
-          Download
+          Download All
         </a>
       </div>
       {isPending && (
@@ -63,6 +85,9 @@ const styles = {
   date: css`
     margin: 0;
     font-size: ${adjustFontSizeTo('16px').fontSize};
+  `,
+  copyInput: css`
+    margin-bottom: 20px;
   `,
   buttons: css`
     display: flex;

--- a/src/components/account/Settings.tsx
+++ b/src/components/account/Settings.tsx
@@ -1,12 +1,12 @@
 import * as theme from '../../styles/theme'
 
 import { Account, ApiKey } from '../../types'
-import React, { useRef, useState } from 'react'
+import React, { useState } from 'react'
 
 import AccountCard from './AccountCard'
 import AccountLayout from './AccountLayout'
 import AddTokenForm from '../AddTokenForm'
-import { CopyButton } from '../EditButtons'
+import { CopyInputWithButton } from '../EditButtons'
 import { RouteComponentProps } from '@reach/router'
 import SVGIcon from '../SVGIcon'
 import Token from './Token'
@@ -48,7 +48,6 @@ interface RemoveKeyMutation {
 }
 
 export default function Settings({ account, location }: Props) {
-  const idRef = useRef<HTMLInputElement>(null)
   const [tokens, setTokens] = useState((account || {}).apiKeys || [])
   const [showForm, setShowForm] = useState(false)
   const [addToken, { loading: addTokenLoading }] = useMutation<
@@ -65,18 +64,9 @@ export default function Settings({ account, location }: Props) {
     <AccountLayout location={location}>
       <h2>Settings</h2>
       <AccountCard title="General" id="general">
-        <div css={styles.row}>
-          <label className="label" htmlFor={`account-${accountId}`}>
-            Project ID
-          </label>
-          <CopyButton title="Copy Account ID" inputRef={idRef} />
-        </div>
-        <input
-          ref={idRef}
-          readOnly
+        <CopyInputWithButton
           id={`account-${accountId}`}
-          type="text"
-          className="input"
+          title="Account ID"
           value={accountId}
         />
       </AccountCard>
@@ -136,12 +126,6 @@ export default function Settings({ account, location }: Props) {
 }
 
 const styles = {
-  row: css`
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
-    align-items: center;
-  `,
   addLink: css`
     display: flex;
     flex-direction: row;

--- a/src/components/account/Token.tsx
+++ b/src/components/account/Token.tsx
@@ -1,6 +1,6 @@
 import * as theme from '../../styles/theme'
 
-import { CopyButton, DeleteButton } from '../EditButtons'
+import { CopyButton, CopyInputWithButton, DeleteButton } from '../EditButtons'
 import {
   MIN_DEFAULT_MEDIA_QUERY,
   MIN_MOBILE_MEDIA_QUERY,
@@ -18,7 +18,6 @@ interface Props {
 }
 
 export default function Token({ token, onDelete }: Props) {
-  const idRef = useRef<HTMLInputElement>(null)
   const secretRef = useRef<HTMLTextAreaElement>(null)
 
   return (
@@ -36,19 +35,10 @@ export default function Token({ token, onDelete }: Props) {
           </div>
           <DeleteButton title="Revoke key" onPress={() => onDelete(token)} />
         </div>
-        <div css={styles.row}>
-          <label className="label" htmlFor={`token-${token.id}`}>
-            Identity
-          </label>
-          <CopyButton title="Copy identity" inputRef={idRef} />
-        </div>
-        <input
-          ref={idRef}
-          readOnly
+        <CopyInputWithButton
           id={`token-${token.id}`}
-          type="text"
-          className="input"
           value={token.id}
+          title="Identity"
         />
       </div>
       <div css={styles.row}>


### PR DESCRIPTION
### PR Checklist

Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [x] I am requesting to **pull a topic/feature/bugfix branch** (right side). In other words, not _master_.
- [x] I have run `npm test` against my changes and tests pass.
- [x] I have added or edited necessary documentation, or no docs changes are needed.

### Description

This adds fields to show and copy URLs for the individual files for NLU models, which is more useful when using `react-native-spokestack` or `react-native-spokestack-tray`.

