### PR TITLE
feat(tutorials): convert tutorial tag list page to its own landing page

### DIFF
--- a/content/blog/announcing-the-export-to-independence-contest/index.md
+++ b/content/blog/announcing-the-export-to-independence-contest/index.md
@@ -41,7 +41,7 @@ Export to Independence is a community contest to see who can best port a smart s
 
 ### Support
 
-- [Tutorials](/blog/tag/tutorial)
+- [Tutorials](/tutorials)
 - [Documentation](/docs)
 - [Community Forum](https://forum.spokestack.io/)
 - Live Video Workshops: Dates to be announced

--- a/content/blog/independence-day/index.md
+++ b/content/blog/independence-day/index.md
@@ -31,9 +31,9 @@ If you've ever read the EULA for smart speaker platforms, you know how rapacious
 
 ## What do I have to do to declare independence?
 
-To further that mission to create a complete developer experience for developing voice apps, we're excited that now you can [export your smart speaker skill](https://spokestack.io/docs/Concepts/export) to run on-device in the major mobile platforms, and declare your independence as an independent voice assistant from smart speakers!
+To further that mission to create a complete developer experience for developing voice apps, we're excited that now you can [export your smart speaker skill](/docs/Concepts/export) to run on-device in the major mobile platforms, and declare your independence as an independent voice assistant from smart speakers!
 
-You can leverage existing ASR and TTS services, which are the parts that actually benefit from scale and are difficult to DIY. Spokestack provides a seamless, unified API across mobile platforms ([iOS](https://spokestack.io/docs/iOS), [Android](https://spokestack.io/docs/Android), and [React/React Native](https://spokestack.io/docs/React%20Native)) that makes converting your skill into a indepedent voice app easy.
+You can leverage existing ASR and TTS services, which are the parts that actually benefit from scale and are difficult to DIY. Spokestack provides a seamless, unified API across mobile platforms ([iOS](/docs/iOS), [Android](/docs/Android), and [React/React Native](/docs/React%20Native)) that makes converting your skill into a indepedent voice app easy.
 
 Finally, like [President Bill Pullman](https://www.imdb.com/title/tt0116629/characters/nm0000597), you must have the hubris to believe.
 

--- a/content/blog/integrating-spokestack-in-react-native/index.md
+++ b/content/blog/integrating-spokestack-in-react-native/index.md
@@ -157,7 +157,7 @@ android {
 
 ## Usage
 
-The [react-native-spokestack-tray example app](https://github.com/spokestack/react-native-spokestack-tray/tree/develop/example) uses the "Spokestack" wakeword and [sample Minecraft NLU models](https://www.spokestack.io/blog/porting-the-alexa-minecraft-skill-to-ios-using-spokestack).
+The [react-native-spokestack-tray example app](https://github.com/spokestack/react-native-spokestack-tray/tree/develop/example) uses the "Spokestack" wakeword and [sample Minecraft NLU models](/blog/porting-the-alexa-minecraft-skill-to-ios-using-spokestack).
 
 In this example, the following code is used to add the `<SpokestackTray />` component:
 

--- a/content/blog/jovo-support-for-spokestack-enables-mobile-app-voice-assistants/index.md
+++ b/content/blog/jovo-support-for-spokestack-enables-mobile-app-voice-assistants/index.md
@@ -17,12 +17,12 @@ Like so many in the voice community, we're big fans of the [Jovo Framework](http
 
 Starting today, Jovo developers can take the following steps to begin building mobile voice experiences based on their Jovo interaction model with Spokestack:
 
-- Create a Spokestack account to gain access to a Spokestack API key: [https://spokestack.io/create](https://spokestack.io/create).
+- Create a Spokestack account to gain access to a Spokestack API key: [https://spokestack.io/create](/create).
 - Add your Spokestack API key and secret to your Jovo project's configuration file.
 - Run the `jovo build` command to create a `platforms/spokestack` directory.
 - Run the `jovo deploy` command to upload your model to Spokestack.
-- Spokestack will then train the imported model for use with Spokestack's [embedded NLU solutions for iOS, Android, and React Native](https://spokestack.io/docs).
-- From there, developers can either follow our [port a smart speaker app to mobile tutorials](https://spokestack.io/blog/tag/tutorial) or build whatever mobile voice experience they have in their heads!
+- Spokestack will then train the imported model for use with Spokestack's [embedded NLU solutions for iOS, Android, and React Native](/docs).
+- From there, developers can either follow our [port a smart speaker app to mobile tutorials](/tutorials) or build whatever mobile voice experience they have in their heads!
 
 ## Why would I import my Jovo model to Spokestack?
 
@@ -34,9 +34,9 @@ We take the interaction model that powers your conversation on smart speakers an
 
 We realize that the barrier to building conversations on mobile is lacking the skills to build apps that work on iOS and Android. Sometimes it's thinking through how voice would work on mobile. We've tried to address both issues.
 
-On iOS, we have [Spokestack Studio](https://apps.apple.com/us/app/spokestack-studio/id1508393980), which was built to show developers exactly how wakewords, speech recognition, text-to-speech, and intent classification work on mobile. It even includes a port of the [Alexa Minecraft Helper](https://spokestack.io/blog/porting-the-alexa-minecraft-skill-to-ios-using-spokestack) skill to iOS.
+On iOS, we have [Spokestack Studio](https://apps.apple.com/us/app/spokestack-studio/id1508393980), which was built to show developers exactly how wakewords, speech recognition, text-to-speech, and intent classification work on mobile. It even includes a port of the [Alexa Minecraft Helper](/blog/porting-the-alexa-minecraft-skill-to-ios-using-spokestack) skill to iOS.
 
-Spokestack Studio isn't available for Android yet, but Spokestack does work on Android. We have another tutorial for [porting an Alexa Skill to Android](https://spokestack.io/blog/porting-the-alexa-minecraft-skill-to-android-using-spokestack) that walks you step-by-step from Alexa skill to Android app. After going through our tutorial, you should be able to port your smart speaker skill to the mobile platform of your choice.
+Spokestack Studio isn't available for Android yet, but Spokestack does work on Android. We have another tutorial for [porting an Alexa Skill to Android](/blog/porting-the-alexa-minecraft-skill-to-android-using-spokestack) that walks you step-by-step from Alexa skill to Android app. After going through our tutorial, you should be able to port your smart speaker skill to the mobile platform of your choice.
 
 ## The future with Jovo
 

--- a/content/blog/porting-the-alexa-minecraft-skill-to-python-using-spokestack/index.md
+++ b/content/blog/porting-the-alexa-minecraft-skill-to-python-using-spokestack/index.md
@@ -288,7 +288,7 @@ OK, that was a lot to cover, but we are almost to the finish line. In the next s
 
 ## Text to Speech (TTS)
 
-Much like the name suggests, [TTS](https://www.spokestack.io/docs/Concepts/tts) translates written text into its spoken form with a synthetic voice. This tutorial assumes you are using our default voice, but if you have a paid plan you can replace `demo-male` with the name of a custom voice. To initialize the [TTSClient](https://github.com/spokestack/spokestack-python/blob/4009a9d8b61cd4375886c66ca0d4a87d99e12153/spokestack/tts/clients/spokestack.py#L20), you simply do the following:
+Much like the name suggests, [TTS](/docs/Concepts/tts) translates written text into its spoken form with a synthetic voice. This tutorial assumes you are using our default voice, but if you have a paid plan you can replace `demo-male` with the name of a custom voice. To initialize the [TTSClient](https://github.com/spokestack/spokestack-python/blob/4009a9d8b61cd4375886c66ca0d4a87d99e12153/spokestack/tts/clients/spokestack.py#L20), you simply do the following:
 
 **Note:** This is another part where you will need your Spokestack API keys. However, notice that the URL for TTS is slightly different than for ASR.
 

--- a/content/blog/tools-and-tips-for-mapping-multimodal-products-remotely/index.md
+++ b/content/blog/tools-and-tips-for-mapping-multimodal-products-remotely/index.md
@@ -7,7 +7,7 @@ author: elizabeth
 draft: false
 ---
 
-At Spokestack, we use [experience mapping](https://spokestack.io/docs/Design/map-out-integration) as a tool to formulate multimodal flows for our products based on [researched observations and ideas](https://spokestack.io/blog/user-research-for-voice-experiences). It’s a great way to get everyone on the same page before designing or building anything. Plus, it forces us to consider _what_ exactly we want users to ask and _how_ we’ll respond, both conversationally and visually. When our team committed to being 100% distributed over two years ago, I wanted to recreate this exercise digitally. What I came up with follows many of the same steps outlined in our [design docs](https://spokestack.io/docs/Design/getting-started). However, the tools and set-up are a bit different. Here are a few considerations to keep in mind when adopting this exercise.
+At Spokestack, we use [experience mapping](/docs/Design/map-out-integration) as a tool to formulate multimodal flows for our products based on [researched observations and ideas](/blog/user-research-for-voice-experiences). It’s a great way to get everyone on the same page before designing or building anything. Plus, it forces us to consider _what_ exactly we want users to ask and _how_ we’ll respond, both conversationally and visually. When our team committed to being 100% distributed over two years ago, I wanted to recreate this exercise digitally. What I came up with follows many of the same steps outlined in our [design docs](/docs/Design/getting-started). However, the tools and set-up are a bit different. Here are a few considerations to keep in mind when adopting this exercise.
 
 ## Tools We Use
 
@@ -37,4 +37,4 @@ These are equally great if not more so for complex maps that capture lots of act
 
 > Not sure where to start? Here’s a [template](https://docs.google.com/spreadsheets/d/1epKA1i_2Cbb8sCEnV_D1mHl4VHfdJhY7-EXZGIrPjbM/edit?usp=sharing) using Google Sheets to get you started. Make sure to duplicate this document before making any changes.
 
-For more tips on designing multimodal voice experiences, visit the [design](https://spokestack.io/docs/Design/getting-started) section of our documentation.
+For more tips on designing multimodal voice experiences, visit the [design](/docs/Design/getting-started) section of our documentation.

--- a/content/blog/user-research-for-voice-experiences/index.md
+++ b/content/blog/user-research-for-voice-experiences/index.md
@@ -11,7 +11,7 @@ Over the last three years, I’ve worked on designing voice and chat conversatio
 
 ## "What can I help you with?"
 
-If you’ve ever said “Hey Siri” to an iOS device, you're likely familiar with the assistant’s opening screen. “What can I help you with?” can be intimidating. You might not be sure what or how Siri can help you, if at all. Siri serves a broad audience (every iPhone user in the world) and an even broader domain of knowledge similar to a search query, which can be overwhelming. [Independent Voice Assistants](https://spokestack.io/blog/what-is-an-independent-voice-assistant) (IVA) serve a more limited domain of knowledge. The actions a user can take, or “intents,” focus on specific tasks in your app like buying movie tickets, recording a run, or finding a cocktail recipe.
+If you’ve ever said “Hey Siri” to an iOS device, you're likely familiar with the assistant’s opening screen. “What can I help you with?” can be intimidating. You might not be sure what or how Siri can help you, if at all. Siri serves a broad audience (every iPhone user in the world) and an even broader domain of knowledge similar to a search query, which can be overwhelming. [Independent Voice Assistants](/blog/what-is-an-independent-voice-assistant) (IVA) serve a more limited domain of knowledge. The actions a user can take, or “intents,” focus on specific tasks in your app like buying movie tickets, recording a run, or finding a cocktail recipe.
 
 With fewer intents, your assistant can provide a better experience without having to know how to respond if a user asks something unrelated like “How many miles to the moon?” But, what intents _do_ \*\*your users care about? To answer that question, you need to start by understanding who you’re building for. Even if you already have an idea of who your target audience is, adding a voice assistant to your mobile app may shift your product’s reach.
 
@@ -70,4 +70,4 @@ After the interview, I like to use recording to document takeaways by doing the 
 
 Don’t forget to re-visit this discussion as needed throughout the design process, especially when testing a product’s usability, to determine if what you’re building remains relevant to your intended audience. In further posts, I will show you how to take this research and turn it into a great voice user experience.
 
-For more help designing independent voice assistants, visit the [design](https://spokestack.io/docs/Design/getting-started) section of our documentation.
+For more help designing independent voice assistants, visit the [design](/docs/Design/getting-started) section of our documentation.

--- a/content/blog/what-to-include-in-a-survey/index.md
+++ b/content/blog/what-to-include-in-a-survey/index.md
@@ -7,7 +7,7 @@ author: elizabeth
 draft: false
 ---
 
-Recruiting folks to test your Voice User Interface (VUI) or [give insights on a concept](https://spokestack.io/blog/user-research-for-voice-experiences) is no easy task. Finding candidates in your target demographic takes time and prowess. You need to know where your users are in order to reach them in the first place. Relying on your network is a great way to quickly get feedback. However, even with old acquaintances, I’ve found myself (maybe not wanting to, but) needing a tool to capture basic demographic information. For this, I recommend using a survey.
+Recruiting folks to test your Voice User Interface (VUI) or [give insights on a concept](/blog/user-research-for-voice-experiences) is no easy task. Finding candidates in your target demographic takes time and prowess. You need to know where your users are in order to reach them in the first place. Relying on your network is a great way to quickly get feedback. However, even with old acquaintances, I’ve found myself (maybe not wanting to, but) needing a tool to capture basic demographic information. For this, I recommend using a survey.
 
 ## Really…you want me to use a survey?
 
@@ -30,4 +30,4 @@ Decide what information is most critical to your research. Understand how your a
 
 Limit open-ended feedback. You’ll be able to further probe for detail when conducting user interviews. Draft your survey and get feedback from those you trust. Here’s a [sample survey](https://docs.google.com/forms/d/1faU7-M5zxTLjpTrweklUl1AELeaKsPMzcY7ipENxL60/edit) I created to get you started.
 
-For more help designing independent voice assistants, visit the [design](https://spokestack.io/docs/Design/getting-started) section of our design documentation.
+For more help designing independent voice assistants, visit the [design](/docs/Design/getting-started) section of our design documentation.

--- a/content/blog/why-we-built-spokestack-tray/index.md
+++ b/content/blog/why-we-built-spokestack-tray/index.md
@@ -22,4 +22,4 @@ With Spokestack Tray, we've created a ready-made "voice kit" that still allows f
 
 `vimeo: [Spokestack Tray Demo](459905947)`
 
-Please check out [Spokestack Tray](https://www.spokestack.io/blog/introducing-spokestack-tray) and tell us what you think. If you have any questions or feedback, email us at [hello@spokestack.io](mailto:hello@spokestack.io), and let's talk conversational interfaces!
+Please check out [Spokestack Tray](/blog/introducing-spokestack-tray) and tell us what you think. If you have any questions or feedback, email us at [hello@spokestack.io](mailto:hello@spokestack.io), and let's talk conversational interfaces!

--- a/content/docs/Concepts/export.md
+++ b/content/docs/Concepts/export.md
@@ -13,7 +13,7 @@ This guide details the process of exporting an existing interaction model from A
 
 2. Copy the contents of your [Interaction Model](https://developer.amazon.com/en-US/docs/alexa/custom-skills/create-the-interaction-model-for-your-skill.html) from the JSON Editor into a file named `{skill_name}.json`.
 
-3. Upload `{skill_name}.json` to the [Spokestack Console](https://spokestack.io/account/services/nlu)
+3. Upload `{skill_name}.json` to the [Spokestack Console](/account/services/nlu)
 
 ## Dialogflow
 
@@ -27,7 +27,7 @@ This guide details the process of exporting an existing interaction model from A
 
 5. Select `Export as zip` and save the `.zip` file.
 
-6. Upload the `.zip` file to the [Spokestack Console](https://spokestack.io/account/services/nlu)
+6. Upload the `.zip` file to the [Spokestack Console](/account/services/nlu)
 
 ## Jovo
 

--- a/content/docs/Design/find-the-right-use-case.md
+++ b/content/docs/Design/find-the-right-use-case.md
@@ -5,7 +5,7 @@ description: Find the right use case for your design
 draft: false
 ---
 
-In our [last article](https://spokestack.io/docs/Design/getting-started), we illustrated the advantages of multimodal interfaces. Some of these are more relevant to certain types of smartphone apps. Before [mapping](https://spokestack.io/docs/Design/docs/Design/map-out-integration) your voice interface, the next step in the design process is to narrow down use cases.
+In our [last article](/docs/Design/getting-started), we illustrated the advantages of multimodal interfaces. Some of these are more relevant to certain types of smartphone apps. Before [mapping](/docs/Design/docs/Design/map-out-integration) your voice interface, the next step in the design process is to narrow down use cases.
 
 Here are some key questions to keep in mind when planning to add voice to a mobile app:
 

--- a/content/docs/Design/tips-for-writing-dialogue.md
+++ b/content/docs/Design/tips-for-writing-dialogue.md
@@ -7,7 +7,7 @@ draft: false
 
 Human-to-human conversation is second nature. Talking to a voice assistant on the other hand doesn’t seem natural, yet is becoming more common. At Spokestack, we support user-initiated, call and response exchanges (often referred to as [system-centric](https://books.google.com/books?id=sxidDwAAQBAJ&pg=PA288&lpg=PA288&dq=system-centric+interaction+conversational+ux&source=bl&ots=GpWt-8ZIjQ&sig=ACfU3U37Qow3LDDcUTf92htxoFYb0pQt7A&hl=en&sa=X&ved=2ahUKEwi_hqvCsovpAhUHWN8KHR0CCDwQ6AEwBnoECAsQAQ#v=onepage&q=system-centric%20interaction%20conversational%20ux&f=false) interactions). These are conducive to voice control and information retrieval.
 
-Below are some ground rules to keep in mind while [writing](https://spokestack.io/docs/Design/script-storyboard-responses) system-centric dialog. These draw from industry standards found in user experience (UX) design, conversational user experience (CUX) design, and conversational analysis (CA) as well as from our own professional experiences. You might recognize some of these from Ben Schneiderman’s [_The Eight Golden Rules of Interface Design_](https://www.cs.umd.edu/users/ben/goldenrules.html) and Paul Grice’s [_Cooperative Principle_](https://en.wikipedia.org/wiki/Cooperative_principle).
+Below are some ground rules to keep in mind while [writing](/docs/Design/script-storyboard-responses) system-centric dialog. These draw from industry standards found in user experience (UX) design, conversational user experience (CUX) design, and conversational analysis (CA) as well as from our own professional experiences. You might recognize some of these from Ben Schneiderman’s [_The Eight Golden Rules of Interface Design_](https://www.cs.umd.edu/users/ben/goldenrules.html) and Paul Grice’s [_Cooperative Principle_](https://en.wikipedia.org/wiki/Cooperative_principle).
 
 ## Start with a greeting
 
@@ -24,7 +24,7 @@ It’s important to craft prompts that are brief, clear, and transparent. Here a
 - Be direct and avoid leading with with an open-ended prompt \*\*\*\*unless the type of feedback you’re looking for warrants it.
 - Provide an example utterance in your instructions. Revealing how to phrase one intent might clue users in on how to say other similar intents.
 
-Here’s an example. As a thought example, imagine you’re working on a fitness tracking app, MyRunBuddy. Information contained in [square brackets] communicates corresponding [visuals](https://spokestack.io/docs/Design/tips-for-designing-visual-output):
+Here’s an example. As a thought example, imagine you’re working on a fitness tracking app, MyRunBuddy. Information contained in [square brackets] communicates corresponding [visuals](/docs/Design/tips-for-designing-visual-output):
 
 ```none
 NEW USER: “Hey Siri, open MyRunBuddy.”
@@ -53,7 +53,7 @@ If designed correctly, users shouldn’t have to to learn how to speak to your a
 When educating new and return users of what they can say, continue to remain brief, clear, and transparent. To do this, consider the following:
 
 - Don’t introduce more than three intents at a time. Providing too many options can impede understanding.
-- Avoid reading long lists such as menu options and [display these items visually](https://spokestack.io/docs/Design/tips-for-designing-visual-output) instead.
+- Avoid reading long lists such as menu options and [display these items visually](/docs/Design/tips-for-designing-visual-output) instead.
 - Say the most important intent (your call to action) either first or last ([golden rule #8:](https://www.cs.umd.edu/users/ben/goldenrules.html) “reduce short-term memory load”). This will help users remember what they can ask, even when unprompted.
 - Be consistent with noun and verbs tenses, especially with lists.
 
@@ -77,7 +77,7 @@ RETURN USER: [Listening] “MyRunBuddy, start a run.”
 MYRUNBUDDY: [Confirmation + Recording Run] “Starting…”
 ```
 
-Since this user has recored a run before using their voice, a follow-up confirmation isn’t required. We’ll [show you examples](https://spokestack.io/docs/Design/tips-for-designing-visual-output) of visuals you might want to include along with aural confirmations later.
+Since this user has recored a run before using their voice, a follow-up confirmation isn’t required. We’ll [show you examples](/docs/Design/tips-for-designing-visual-output) of visuals you might want to include along with aural confirmations later.
 
 #### Use sounds such as “earcons” or “liveliness indicators”
 
@@ -100,7 +100,7 @@ In this example, the app misheard the user’s `stop` intent for `start`. The ap
 
 ## Consider how a user provided input & respond in kind
 
-Voice input for complex queries is faster and more convenient, especially for users who are multitasking. And yet, the average person can read faster than they can listen. Respect your users’ time. It’s not necessary to respond with the same amount of information you would for a smart speaker skill. A well-crafted response will increase re-engagement. Consider whether a voice response, a [visual response](https://spokestack.io/docs/Design/tips-for-designing-visual-output), or both is appropriate and be consistent with which mode you use ([golden rule #1:](https://www.cs.umd.edu/users/ben/goldenrules.html) “strive for consistency”). For example, if a user used their voice, a brief voice response might make the most sense.
+Voice input for complex queries is faster and more convenient, especially for users who are multitasking. And yet, the average person can read faster than they can listen. Respect your users’ time. It’s not necessary to respond with the same amount of information you would for a smart speaker skill. A well-crafted response will increase re-engagement. Consider whether a voice response, a [visual response](/docs/Design/tips-for-designing-visual-output), or both is appropriate and be consistent with which mode you use ([golden rule #1:](https://www.cs.umd.edu/users/ben/goldenrules.html) “strive for consistency”). For example, if a user used their voice, a brief voice response might make the most sense.
 
 Here are a few other considerations:
 

--- a/content/docs/React Native/cookbook.md
+++ b/content/docs/React Native/cookbook.md
@@ -117,7 +117,7 @@ onClassification (e) {
 
 ### Synthesis speech formatted with [SpeechMarkdown](https://www.speechmarkdown.org/)
 
-When creating a synthesis request, the request takes a dictionary with specific keys. The `id` field is for your convenience, and `voice` may be changed by creating a [Spokestack account](https://spokestack.io/account). The `input` is where the SpeechMarkdown-formatted text will be placed.
+When creating a synthesis request, the request takes a dictionary with specific keys. The `id` field is for your convenience, and `voice` may be changed by creating a [Spokestack account](/account). The `input` is where the SpeechMarkdown-formatted text will be placed.
 
 ```javascript
 Spokestack.synthesize({

--- a/content/docs/iOS/speech-pipeline.md
+++ b/content/docs/iOS/speech-pipeline.md
@@ -44,7 +44,7 @@ When active, audio frames are not processed on-device but are instead sent to an
 Spokestack offers several pre-built "profiles" that bundle stage classes and in some cases configuration properties tuned to support different app configurations. See the [API reference](https://spokestack.github.io/spokestack-ios/Classes/SpeechPipeline.html) for for a complete listing, but here's a brief summary:
 
 - Profiles whose names begin with `vadTrigger` send any detected speech straight to the chosen speech recognizer.
-- `Wakeword` profiles use either [TensorFlow Lite](https://www.tensorflow.org/lite) or an ASR-filtered wakeword triggered pipeline activation. [See an explainer](https://spokestack.io/blog/choosing-the-right-ios-wakeword-service) for how to choose between wakeword profiles.
+- `Wakeword` profiles use either [TensorFlow Lite](https://www.tensorflow.org/lite) or an ASR-filtered wakeword triggered pipeline activation. [See an explainer](/blog/choosing-the-right-ios-wakeword-service) for how to choose between wakeword profiles.
 - `pushToTalk` profiles have no automatic triggering; the pipeline's `activate` method must be called to perform speech recognition.
 
 Profiles take care of all configuration that can be managed in a one-size-fits-all fashion. For example, note the paths to the wakeword models in the example above. Some components require additional configuration, such as third-party API keys, paths to TensorFlow models, or the `DispatchQueue` for sending events that are received on the UI thread.

--- a/content/docs/welcome.md
+++ b/content/docs/welcome.md
@@ -53,7 +53,7 @@ Tutorials for integrating Spokestack are also available on our blog:
 - [iOS Tutorial](/blog/porting-a-smart-speaker-voice-app-to-mobile-part-1)
 - [Android Tutorial](/blog/porting-the-alexa-minecraft-skill-to-android-using-spokestack)
 
-Check our blog for all of our [Spokestack Tutorials](/blog/tag/tutorial).
+Check our blog for all of our [Spokestack Tutorials](/tutorials).
 
 ### Design Resources
 

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -5,7 +5,7 @@ import { getDarkModePref } from './src/utils/auth'
 
 export { default as wrapRootElement } from './src/apollo/wrapRootElement'
 
-const rdark = /^\/(?:docs|blog)/
+const rdark = /^\/(?:docs|blog|tutorials)/
 
 export const onClientEntry = () => {
   // IntersectionObserver polyfill for gatsby-background-image (Safari, IE)

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -143,7 +143,10 @@ async function createTagPages({ tag, tags, actions, graphql }) {
   }
   const posts = result.data.allMarkdownRemark.edges
   const numPages = Math.ceil(posts.length / postsPerPage)
-  const url = `/blog/tag/${tag.toLowerCase().replace(rspaces, '-')}`
+  const url =
+    tag === 'Tutorial'
+      ? '/tutorials'
+      : `/blog/tag/${tag.toLowerCase().replace(rspaces, '-')}`
   Array.from({ length: numPages }).forEach((_, i) => {
     createPage({
       path: i === 0 ? url : `${url}/${i + 1}`,
@@ -155,7 +158,7 @@ async function createTagPages({ tag, tags, actions, graphql }) {
         skip: i * postsPerPage,
         slug: url,
         tag,
-        tags,
+        tags: tag === 'Tutorial' ? [] : tags,
         total: posts.length
       }
     })

--- a/src/components/BlogList.tsx
+++ b/src/components/BlogList.tsx
@@ -11,7 +11,6 @@ import DarkModeButton from '../components/DarkModeButton'
 import Layout from '../components/Layout'
 import { MarkdownRemarkEdge } from '../utils/graphql'
 import React from 'react'
-import SEO from './SEO'
 import SVGIcon from '../components/SVGIcon'
 import Tags from '../components/Tags'
 import { WindowLocation } from '@reach/router'
@@ -59,15 +58,13 @@ export default function BlogList({
           }
         `}
       />
-      <SEO
-        title="Voice App Developer Blog — Spokestack"
-        description="The Spokestack blog shares articles for voice assistant and app creators and enthusiasts. See product updates and tips to build better voice experiences."
-      />
       <div className="blog-list ie-fix" css={[styles.container, extraCss]}>
         <div className="bg-banner" css={styles.bgBanner} />
         <section css={styles.blogContent}>
           <div className="sidenav" css={styles.sidenav}>
-            <Tags allUrl="/blog" header="Tags" tags={tags} />
+            {tags && !!tags.length && (
+              <Tags allUrl="/blog" header="Tags" tags={tags} />
+            )}
           </div>
           <div css={styles.content}>
             {header ? (

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -64,9 +64,9 @@ export default function Footer() {
           <Link css={styles.footerLink} to="/docs">
             Developer Docs
           </Link>
-          {/* <a css={styles.footerLink} href="/blog/tag/tutorial">
+          <a css={styles.footerLink} href="/tutorials">
             Tutorials
-          </a> */}
+          </a>
           <Link css={styles.footerLink} to="/blog">
             Blog
           </Link>

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -22,7 +22,7 @@ interface Props {
   location: WindowLocation
 }
 
-export default function Nav({ extraCss, location }: Props) {
+export default function Nav({ extraCss }: Props) {
   const [mobileOpen, setMobileOpen] = useState(false)
   const contentStyles = [styles.navContent]
   if (mobileOpen) {
@@ -97,7 +97,7 @@ export default function Nav({ extraCss, location }: Props) {
                   />
                   <NavLinkDropdown
                     extraCss={styles.navLinkDropdown}
-                    href="/blog/tag/tutorial"
+                    href="/tutorials"
                     title="Tutorials"
                     imageUrl="/navigation/tutorials.svg"
                     text="Step-by-step instructions to build real-world products"
@@ -105,11 +105,10 @@ export default function Nav({ extraCss, location }: Props) {
                   <NavLinkDropdown
                     extraCss={styles.navLinkDropdown}
                     href="/blog"
-                    partiallyActive={location.pathname !== '/blog/tag/tutorial'}
+                    partiallyActive
                     title="Blog"
                     imageUrl="/navigation/blog.svg"
-                    text="How-to articles on creating voice assistants from our
-                    team"
+                    text="How-to articles on creating voice assistants from our team"
                   />
                 </div>
                 <div css={styles.dropdownColumn}>
@@ -117,8 +116,7 @@ export default function Nav({ extraCss, location }: Props) {
                     extraCss={styles.navLinkDropdown}
                     title="Libraries"
                     imageUrl="/navigation/libraries.svg"
-                    text="Build a voice-enabled app using one of our open source
-                    libraries:">
+                    text="Build a voice-enabled app using one of our open source libraries:">
                     <Libraries />
                   </NavLinkDropdown>
                 </div>

--- a/src/components/SEO.tsx
+++ b/src/components/SEO.tsx
@@ -48,11 +48,7 @@ export default function SEO({
         lang
       }}
       title={title}
-      titleTemplate={
-        site.siteMetadata.title === title
-          ? `%s`
-          : `${site.siteMetadata.title} | %s`
-      }
+      titleTemplate="%s"
       meta={[
         {
           name: 'description',

--- a/src/pages/about/story.tsx
+++ b/src/pages/about/story.tsx
@@ -7,7 +7,7 @@ export default function Story({ location }: PageRendererProps) {
   return (
     <AboutLayout location={location}>
       <SEO
-        title="Giving Every App a Voice — Spokestack"
+        title="Giving Every App a Voice | Spokestack"
         description="Our team has worked together on voice user interfaces (VUI) for over three years. Our mission is to give every mobile app a voice."
       />
       <h1>Story</h1>

--- a/src/pages/about/team.tsx
+++ b/src/pages/about/team.tsx
@@ -10,7 +10,7 @@ export default function Team({ location }: PageRendererProps) {
   return (
     <AboutLayout location={location}>
       <SEO
-        title="Team — Spokestack"
+        title="Team | Spokestack"
         description="From our CEO and CTO to Engineering to UX &amp; Product Design, we've built a robust and experienced text to speech development team at Spokestack. Meet us."
       />
       <h1 css={styles.header}>Team</h1>

--- a/src/pages/blog/tag/tutorial.tsx
+++ b/src/pages/blog/tag/tutorial.tsx
@@ -3,7 +3,7 @@ import { useEffect } from 'react'
 
 export default function About(): null {
   useEffect(() => {
-    navigate('/about/story', { replace: true })
+    navigate('/tutorials', { replace: true })
   }, [])
   return null
 }

--- a/src/pages/create.tsx
+++ b/src/pages/create.tsx
@@ -10,7 +10,7 @@ export default function createPage({ location }: PageRendererProps) {
       header="Create a free account, no credit card required"
       location={location}>
       <SEO
-        title="Create a Free Voice App Developer Account — Spokestack"
+        title="Create a Free Voice App Developer Account | Spokestack"
         description="Create a free account — no credit card required. Get access to Spokestack's API training and support resources for VUI, NLU, TTS, and more."
       />
     </Login>

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -7,7 +7,7 @@ export default function createPage({ location }: PageRendererProps) {
   return (
     <Login header="Sign in using GitHub or Google" location={location}>
       <SEO
-        title="Sign In — Spokestack"
+        title="Sign In | Spokestack"
         description="Log in to Spokestack to access our voice assistant developer API, access our on-device NLU engine, see our library of TTS voices, get support, and more."
       />
     </Login>

--- a/src/pages/pricing.tsx
+++ b/src/pages/pricing.tsx
@@ -51,7 +51,7 @@ export default function Pricing({ data, location }: Props) {
   return (
     <Layout location={location}>
       <SEO
-        title="Pricing — Spokestack"
+        title="Pricing | Spokestack"
         description="Choose the right plan for you: Free, Pro, or Enterprise. We support Automatic Speech Recognition, Natural Language Understanding, and Text to Speech."
       />
       <div

--- a/src/pages/support.tsx
+++ b/src/pages/support.tsx
@@ -19,7 +19,7 @@ export default function Support({ data, location }: Props) {
   return (
     <Layout location={location}>
       <SEO
-        title="Text to Speech Voice Integration Support — Spokestack"
+        title="Text to Speech Voice Integration Support | Spokestack"
         description="We offer multiple support channels that best suit your text to speech topic or voice product. Choose from GitHub, Twitter, Stack Overflow, or our Forum."
       />
       <div css={styles.container}>

--- a/src/templates/blog-list-author.tsx
+++ b/src/templates/blog-list-author.tsx
@@ -9,6 +9,7 @@ import { MIN_DEFAULT_MEDIA_QUERY } from 'typography-breakpoint-constants'
 import { PageContext } from '../types'
 import { Query } from '../utils/graphql'
 import React from 'react'
+import SEO from '../components/SEO'
 import SocialLink from '../components/SocialLink'
 import find from 'lodash/find'
 
@@ -39,6 +40,10 @@ export default function BlogListAuthorTemplate({
             }
           }
         `}
+      />
+      <SEO
+        title="Voice App Developer Blog | Spokestack"
+        description="The Spokestack blog shares articles for voice assistant and app creators and enthusiasts. See product updates and tips to build better voice experiences."
       />
       <BlogList
         currentPage={currentPage}

--- a/src/templates/blog-list-tag.tsx
+++ b/src/templates/blog-list-tag.tsx
@@ -4,10 +4,18 @@ import BlogList from '../components/BlogList'
 import { PageContext } from '../types'
 import { Query } from '../utils/graphql'
 import React from 'react'
+import SEO from '../components/SEO'
 
 type Props = PageRendererProps & {
   data: Query
   pageContext: PageContext
+}
+
+const descriptions = {
+  tags:
+    'The Spokestack blog shares articles for voice assistant and app creators and enthusiasts. See product updates and tips to build better voice experiences.',
+  tutorials:
+    'Learn from Spokestack developers, app creators, and enthusiasts and build your own independent voice assistant.'
 }
 
 export default function BlogListTagTemplate({
@@ -15,18 +23,29 @@ export default function BlogListTagTemplate({
   location,
   pageContext: { currentPage, numPages, slug, tag, tags, total }
 }: Props) {
+  const isTutorial = tag === 'Tutorial'
   const posts = data.allMarkdownRemark.edges
-  const longTitle = `${total} articles tagged with "${tag}"`
+  const longTitle = isTutorial
+    ? 'Tutorials'
+    : `${total} articles tagged with "${tag}"`
   return (
-    <BlogList
-      currentPage={currentPage}
-      homeUrl={slug}
-      location={location}
-      numPages={numPages}
-      posts={posts}
-      tags={tags}
-      title={longTitle}
-    />
+    <>
+      <SEO
+        title={`Voice App Developer ${
+          isTutorial ? 'Tutorials' : 'Blog'
+        } | Spokestack`}
+        description={isTutorial ? descriptions.tutorials : descriptions.tags}
+      />
+      <BlogList
+        currentPage={currentPage}
+        homeUrl={slug}
+        location={location}
+        numPages={numPages}
+        posts={posts}
+        tags={tags}
+        title={longTitle}
+      />
+    </>
   )
 }
 

--- a/src/templates/blog-list.tsx
+++ b/src/templates/blog-list.tsx
@@ -4,6 +4,7 @@ import BlogList from '../components/BlogList'
 import { PageContext } from '../types'
 import { Query } from '../utils/graphql'
 import React from 'react'
+import SEO from '../components/SEO'
 
 type Props = PageRendererProps & {
   data: Query
@@ -17,15 +18,21 @@ export default function BlogListTemplate({
   pageContext: { numPages, currentPage, slug, tags }
 }: Props) {
   return (
-    <BlogList
-      currentPage={currentPage}
-      homeUrl={slug}
-      location={location}
-      numPages={numPages}
-      posts={data.allMarkdownRemark.edges}
-      tags={tags}
-      title="Blog"
-    />
+    <>
+      <SEO
+        title="Voice App Developer Blog | Spokestack"
+        description="The Spokestack blog shares articles for voice assistant and app creators and enthusiasts. See product updates and tips to build better voice experiences."
+      />
+      <BlogList
+        currentPage={currentPage}
+        homeUrl={slug}
+        location={location}
+        numPages={numPages}
+        posts={data.allMarkdownRemark.edges}
+        tags={tags}
+        title="Blog"
+      />
+    </>
   )
 }
 


### PR DESCRIPTION
### PR Checklist

Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [x] I am requesting to **pull a topic/feature/bugfix branch** (right side). In other words, not _master_.
- [x] I have run `npm test` against my changes and tests pass.
- [x] I have added or edited necessary documentation, or no docs changes are needed.

### Description

This alters the landing page for the Tutorial tag list page to be more specific, and places that page at `/tutorials` instead of at `/blog/tag/tutorial`. A redirect was also put in place for back-compat.

