### PR TITLE
feat(login): fix redirects for GitHub OAuth on beta and localhost

### DIFF
--- a/src/utils/oauthGitHub.ts
+++ b/src/utils/oauthGitHub.ts
@@ -1,11 +1,19 @@
 import { getStateKey, setAuthToken, setProvider } from './auth'
 
-const clientId = process.env.SS_GITHUB_CLIENT_ID
+const clientIds: { [key: string]: string } = {
+  'https://www.spokestack.io': process.env.SS_GITHUB_CLIENT_ID,
+  'https://beta.spokestack.io': process.env.SS_BETA_GITHUB_CLIENT_ID,
+  'http://localhost:8000': process.env.SS_LOCAL_GITHUB_CLIENT_ID
+}
 const apiUrl = process.env.SS_API_URL
+
+function getClientId() {
+  return clientIds[process.env.SITE_URL]
+}
 
 export function createLink() {
   let url = 'https://github.com/login/oauth/authorize'
-  url += `?client_id=${clientId}`
+  url += `?client_id=${getClientId()}`
   url += '&scope=read:user,user:email'
   url += `&state=${getStateKey()}`
   return url
@@ -25,7 +33,7 @@ export async function getAccessToken(
       'Content-Type': 'application/json'
     },
     body: JSON.stringify({
-      client_id: clientId,
+      client_id: getClientId(),
       code,
       state: stateFromGH
     })


### PR DESCRIPTION
**Currently a Draft because changes are needed in the API for this to work**

### PR Checklist

Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [x] I am requesting to **pull a topic/feature/bugfix branch** (right side). In other words, not _master_.
- [x] I have run `npm test` against my changes and tests pass.
- [x] I have added or edited necessary documentation, or no docs changes are needed.

### Description

- I've added 2 new OAuth apps to our Spokestack org to cover beta and localhost
  separately (since you can only have one callback URL per application). Google
  does not have that restriction so does not need a fix.
- This fix is dependent on a change to https://api.spokesatck.io/authorize/github
  to support the 2 new client IDs (and thus client secrets)

