### PR TITLE
feat(pricing): add free trial to pricing page

### DIFF
--- a/src/components/pricing/Header.tsx
+++ b/src/components/pricing/Header.tsx
@@ -8,26 +8,30 @@ export interface HeaderProps {
   cta: string
   name: React.ReactNode
   price: string
+  subtitle?: string
   slug?: string
 }
 
-export default function Header({ cta, name, price, slug }: HeaderProps) {
+export default function Header({
+  cta,
+  name,
+  price,
+  subtitle,
+  slug
+}: HeaderProps) {
   return (
     <header css={styles.pricingHeader}>
       <h4 className="blue">{name}</h4>
       <h3>{price}</h3>
-      {cta === 'Coming soon' ? (
-        <p>{cta}</p>
-      ) : (
-        <a href={slug}>
-          {cta}
-          <SVGIcon
-            className="icon"
-            icon="#arrow-forward"
-            extraCss={styles.iconArrow}
-          />
-        </a>
-      )}
+      <a href={slug}>
+        {cta}
+        <SVGIcon
+          className="icon"
+          icon="#arrow-forward"
+          extraCss={styles.iconArrow}
+        />
+      </a>
+      {!!subtitle && <p css={styles.subtitle}>{subtitle}</p>}
     </header>
   )
 }
@@ -36,9 +40,10 @@ const styles = {
   pricingHeader: css`
     display: flex;
     flex-direction: column;
-    justify-content: center;
+    justify-content: flex-start;
     align-items: center;
     text-align: center;
+    height: 170px;
 
     h4 {
       position: relative;
@@ -59,11 +64,15 @@ const styles = {
       align-items: center;
       text-decoration: none;
       font-weight: 400;
+      margin-bottom: 10px;
 
       &:hover .icon {
         fill: ${theme.linkHover};
       }
     }
+  `,
+  subtitle: css`
+    font-size: 14px;
   `,
   iconArrow: css`
     width: 18px;

--- a/src/components/pricing/Plan.tsx
+++ b/src/components/pricing/Plan.tsx
@@ -3,7 +3,6 @@ import * as theme from '../../styles/theme'
 import Category, { CategoryProps } from './Category'
 import Header, { HeaderProps } from './Header'
 
-import Button from '../Button'
 import React from 'react'
 import { css } from '@emotion/react'
 
@@ -16,13 +15,12 @@ interface Props extends HeaderProps {
 
 export default function Plan({
   background,
-  cta,
   extraHeader,
-  name,
-  price,
-  slug,
   categories,
-  showBanners
+  showBanners,
+  cta,
+  slug,
+  ...headerProps
 }: Props) {
   return (
     <div css={styles.plan}>
@@ -31,7 +29,7 @@ export default function Plan({
         className="ie-fix"
         style={{ backgroundColor: background || 'white' }}>
         {extraHeader}
-        <Header cta={cta} name={name} price={price} slug={slug} />
+        <Header {...headerProps} cta={cta} slug={slug} />
         {categories.map((category) => (
           <Category
             key={category.name}
@@ -40,15 +38,9 @@ export default function Plan({
           />
         ))}
       </div>
-      {cta === 'Coming soon' ? (
-        <Button disabled transparent>
-          {cta}
-        </Button>
-      ) : (
-        <a href={slug} className="btn btn-transparent" tabIndex={0} title={cta}>
-          {cta}
-        </a>
-      )}
+      <a href={slug} className="btn btn-transparent" tabIndex={0} title={cta}>
+        {cta}
+      </a>
     </div>
   )
 }

--- a/src/pages/pricing.tsx
+++ b/src/pages/pricing.tsx
@@ -153,7 +153,7 @@ export default function Pricing({ data, location }: Props) {
         />
         <Plan
           cta={loggedIn ? 'Upgrade' : 'Create account'}
-          slug={loggedIn ? '/account/settings#billing' : '/account/create'}
+          slug={loggedIn ? '/account/upgrade' : '/account/create'}
           background={theme.primaryLighter}
           extraHeader={
             <Switch
@@ -172,6 +172,7 @@ export default function Pricing({ data, location }: Props) {
             </Fragment>
           }
           price={yearly ? '$99.99/yr' : '$9.99/mo'}
+          subtitle="With 5-day free trial"
           categories={[
             {
               name: 'Automatic Speech Recognition (ASR)',
@@ -394,7 +395,7 @@ const styles = {
   saveBadge: css`
     position: absolute;
     top: -4px;
-    left: -50px;
+    left: -48px;
     width: 41px;
     height: 41px;
     display: flex;


### PR DESCRIPTION
### PR Checklist

Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [x] I am requesting to **pull a topic/feature/bugfix branch** (right side). In other words, not _master_.
- [x] I have run `npm test` against my changes and tests pass.
- [x] I have added or edited necessary documentation, or no docs changes are needed.

### Description

Adds a subtitle to the Plan component and 5-day free trial messaging to the Maker plan.

![image](https://user-images.githubusercontent.com/192451/115067439-e7828e80-9ebe-11eb-92fc-cb60f4e8d53e.png)
